### PR TITLE
Update `pipeline.py` --> `recipe.py` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the starting place for a new pipeline recipe, welcome!
 
 To add a new recipe, you'll open a pull request containing:
 
-1. A `recipes/<Your recipe name>/meta.yaml` file, containing the metadata for your dataset
-2. A `recipes/<Your recipe name>/recipe.py` file, a Python module with actual pipeline definition.
+1. A `recipes/<Your feedstock name>/meta.yaml` file, containing the metadata for your dataset
+2. A `recipes/<Your feedstock name>/recipe.py` file, a Python module with actual pipeline definition.
 
 See below for help on writing those files.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # staged-recipes
 
-This is the starting place for a new pipeline recipe, welcome!
+This is the starting place for a new recipe, welcome!
 
 ## Adding a new Recipe
 
 To add a new recipe, you'll open a pull request containing:
 
 1. A `recipes/<Your feedstock name>/meta.yaml` file, containing the metadata for your dataset
-2. A `recipes/<Your feedstock name>/recipe.py` file, a Python module with actual pipeline definition.
+2. A `recipes/<Your feedstock name>/recipe.py` file, a Python module with recipe (or recipe dict-object) definition.
 
 See below for help on writing those files.
 
@@ -15,16 +15,16 @@ Once your recipe is ready (or if you get stuck and need help), open a pull
 request from your fork of ``pangeo-forge/staged-recipes``. A team of bots and
 pangeo-forge maintainers will help get your new recipe ready to go.
 
-## Developing a Pipeline
+## Developing a Recipe
 
-New pipelines can be developed locally or on Pangeo's binder. During the development
-of the pipeline, you shouldn't need to download or process very large amounts of
-data, so eitehr should be fine. If you want to work remotely on Pangeo's binder,
+New recipes can be developed locally or on Pangeo's binder. During the development
+of the recipe, you shouldn't need to download or process very large amounts of
+data, so either should be fine. If you want to work remotely on Pangeo's binder,
 follow this URL:
 
 https://staging.binder.pangeo.io/v2/gh/pangeo-forge/docker-images/master?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fpangeo-forge%252Fstaged-recipes%26urlpath%3Dlab%252Ftree%252Fstaged-recipes%252FREADME.md%26branch%3Dmaster
 
 If you're working locally, you'll need to clone https://github.com/pangeo-forge/staged-recipes.
 
-1. Copy the example pipeline.
+1. Copy the example recipe.
 2.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the starting place for a new pipeline recipe, welcome!
 
 To add a new recipe, you'll open a pull request containing:
 
-1. A `recipe/meta.yaml` file, containing the metadata for your dataset
-2. A `recipe/pipeline.py` file, a Python module with actual pipeline definition.
+1. A `recipes/<Your recipe name>/meta.yaml` file, containing the metadata for your dataset
+2. A `recipes/<Your recipe name>/recipe.py` file, a Python module with actual pipeline definition.
 
 See below for help on writing those files.
 


### PR DESCRIPTION
This PR addresses one aspect of the broader work discussed in #32. Motivated by @paigem's question in https://github.com/pangeo-forge/staged-recipes/pull/56#issue-678618312.

One thing I remain unclear on, is whether or not `<Your recipe name>` is the correct way to describe the name of the directory we want contributors to add in their PRs? Perhaps this should instead be something like, `<Your feedstock name>`?

@sharkinsspatial, do you know what will happen with these directories when they are merged? I believe, following `conda-forge`'s example, they will become standalone repos within the `pangeo-forge` org? I feel like this is may be in an ADR somewhere, but not sure which one, and either way wanted to take the opportunity to start a conversation about merging some recipe PR's.