### PR TITLE
Add workflow to update commit with Prefect test flow run status.

### DIFF
--- a/.github/workflows/run-recipe-test.yaml
+++ b/.github/workflows/run-recipe-test.yaml
@@ -49,3 +49,4 @@ jobs:
           PREFECT__CLOUD__AUTH_TOKEN: ${{ secrets.PREFECT__CLOUD__AUTH_TOKEN }}
           PREFECT_PROJECT_NAME: ${{ secrets.PREFECT_PROJECT_NAME }}
           GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
+          COMMENT_ID: ${{ github.event.client_payload.comment.id }}

--- a/.github/workflows/update-slash-command-comment.yaml
+++ b/.github/workflows/update-slash-command-comment.yaml
@@ -1,0 +1,25 @@
+name: Update Slash Command Comment
+on:
+  repository_dispatch:
+    types: [prefect_webhook]
+jobs:
+  update_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set emoji type from Flow status
+        env:
+          PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
+        run: |
+          echo "$PAYLOAD_CONTEXT"
+          if [[ ${{ github.event.client_payload.state }} == "Success" ]]; then
+            echo "EDIT=:white_check_mark:" >> $GITHUB_ENV
+          else
+            echo "EDIT=:x:" >> $GITHUB_ENV
+          fi
+
+      - name: Add emoji to comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: "${{ github.event.client_payload.flow_run_id }}"
+          body: |
+            ${{ env.EDIT }}


### PR DESCRIPTION
Add workflow to update the slash-command trigger comment with the results of the Prefect test flow using a dispatch webhook. See https://github.com/pangeo-forge/pangeo-forge-prefect/pull/18 for more details on how this webhook registration is handled internally by the prefect-recipe-action.