### PR TITLE
Add notebook links following successful `/run-recipe-test`

### DIFF
--- a/.github/workflows/update-slash-command-comment.yaml
+++ b/.github/workflows/update-slash-command-comment.yaml
@@ -12,7 +12,10 @@ jobs:
         run: |
           echo "$PAYLOAD_CONTEXT"
           if [[ ${{ github.event.client_payload.state }} == "Success" ]]; then
-            echo "EDIT=:white_check_mark:" >> $GITHUB_ENV
+            echo "EDIT=\":white_check_mark: Success!
+            This is line 2.
+            Line 3.\"
+            " >> $GITHUB_ENV
           else
             echo "EDIT=:x:" >> $GITHUB_ENV
           fi

--- a/recipes/noaa-oisst-actions-test/meta.yaml
+++ b/recipes/noaa-oisst-actions-test/meta.yaml
@@ -1,0 +1,26 @@
+title: "NOAA Optimum Interpolated SST"
+description: "Analysis-ready Zarr datasets derived from NOAA OISST NetCDF"
+pangeo_forge_version: "0.5.0"
+pangeo_notebook_version: "2021.07.17"
+recipes:
+  - id: noaa-oisst-avhrr-only
+    object: "recipe:recipe"
+provenance:
+  providers:
+    - name: "NOAA NCEI"
+      description: "National Oceanographic & Atmospheric Administration National Centers for Environmental Information"
+      roles:
+        - producer
+        - licensor
+      url: https://www.ncdc.noaa.gov/oisst
+  license: "CC-BY-4.0"
+maintainers:
+  - name: "Ryan Abernathey"
+    orcid: "0000-0001-5999-4917"
+    github: rabernat
+bakery:
+  id: "devseed.bakery.development.aws.us-west-2"  # must come from a valid list of bakeries
+  target: pangeo-forge-aws-bakery-flowcachebucketdasktest4-10neo67y7a924
+  resources:
+    memory: 4096
+    cpu: 1024

--- a/recipes/noaa-oisst-actions-test/meta.yaml
+++ b/recipes/noaa-oisst-actions-test/meta.yaml
@@ -3,7 +3,7 @@ description: "Analysis-ready Zarr datasets derived from NOAA OISST NetCDF"
 pangeo_forge_version: "0.5.0"
 pangeo_notebook_version: "2021.07.17"
 recipes:
-  - id: noaa-oisst-avhrr-only
+  - id: noaa-oisst-avhrr-only-actions-test
     object: "recipe:recipe"
 provenance:
   providers:

--- a/recipes/noaa-oisst-actions-test/recipe.py
+++ b/recipes/noaa-oisst-actions-test/recipe.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+
+start_date = "1981-09-01"
+
+
+def format_function(time):
+    base = pd.Timestamp(start_date)
+    day = base + pd.Timedelta(days=time)
+    input_url_pattern = (
+        "https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation"
+        "/v2.1/access/avhrr/{day:%Y%m}/oisst-avhrr-v02r01.{day:%Y%m%d}.nc"
+    )
+    return input_url_pattern.format(day=day)
+
+
+dates = pd.date_range(start_date, "2021-01-05", freq="D")
+pattern = FilePattern(format_function, ConcatDim("time", range(len(dates)), 1))
+recipe = XarrayZarrRecipe(pattern, inputs_per_chunk=20, cache_inputs=True)


### PR DESCRIPTION
Following @rabernat's suggestion in https://github.com/pangeo-forge/staged-recipes/pull/74#issuecomment-916411092, if `/run-recipe-test` succeeds, the action should provide static and/or binderized notebook links so the contributor can gut-check that the build produces the data they are expecting.

To start, this PR just adds a duplicate of the `noaa-oisst` recipe for testing, and makes the success comment a multi-line placeholder. I'll be running the `/run-recipe-test` action a number of times on this PR as I work through this.

I wish there was a way to use something like https://github.com/nektos/act for local testing, but given that https://github.com/marketplace/actions/create-or-update-comment is posting changes to GitHub comments, it seems unavoidable to test here.

