### PR TITLE
Add pull request dispatch to registrar

### DIFF
--- a/.github/workflows/dispatch-pull-request-commit.yaml
+++ b/.github/workflows/dispatch-pull-request-commit.yaml
@@ -1,0 +1,23 @@
+name: Create recipe runs
+
+on:
+  pull_request:
+    branches: master
+    paths:
+      - 'recipes/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      FEEDSTOCK_SPEC: "${{ github.repository }}"
+      HEAD_SHA: "${{ github.sha }}"
+      PR_NUMBER: "${{ github.event.pull_request.number }}"
+    steps:
+      - name: dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: pangeo-forge/registrar
+          event-type: pull-request-commit
+          client-payload: '{"feedstock_spec": "${{ env.FEEDSTOCK_SPEC }}", "head_sha": "${{ env.HEAD_SHA }}", "pr_number": "${{ env.PR_NUMBER }}"}'


### PR DESCRIPTION
The workflow added by this PR notifies this other workflow:

https://github.com/pangeo-forge/registrar/blob/create-recipe-run/.github/workflows/receive-pull-request-commit.yaml

that a pull request event has occurred in `staged-recipes` which in turn asks the microservice for registering recipe runs from PR commits to run. Further documentation to follow.