### PR TITLE
CMIP6 NorESM2-LM historical vmo data

### DIFF
--- a/recipes/noresm2-lm-hist-vmo/meta.yaml
+++ b/recipes/noresm2-lm-hist-vmo/meta.yaml
@@ -1,0 +1,22 @@
+title: "CMIP6 NorESM2-LM historical vmo"
+description: "Analysis-ready Zarr datasets derived from ESGF provided NetCDF files of ocean mass y transport"
+pangeo_forge_version: "0.8.2"
+pangeo_notebook_version: "2021.07.17"
+recipes:
+  - id: noresm2-lm-hist-vmo
+    object: "recipe:recipe"
+provenance:
+  providers:
+    - name: "NorESM Climate modeling Consortium"
+      description: "CICERO (Center for International Climate and Environmental Research, Oslo 0349), MET-Norway (Norwegian Meteorological Institute, Oslo 0313), NERSC (Nansen Environmental and Remote Sensing Center, Bergen 5006), NILU (Norwegian Institute for Air Research, Kjeller 2027), UiB (University of Bergen, Bergen 5007), UiO (University of Oslo, Oslo 0313) and UNI (Uni Research, Bergen 5008), Norway."
+      roles:
+        - producer
+        - licensor
+      url: https://www.ncdc.noaa.gov/oisst
+  license: "Creative Commons Attribution ShareAlike 4.0 International License"
+maintainers:
+  - name: "Dianne Deauna"
+    orcid: "0000-0002-0733-9440"
+    github: jdldeuana
+bakery:
+  id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/noresm2-lm-hist-vmo/recipe.py
+++ b/recipes/noresm2-lm-hist-vmo/recipe.py
@@ -1,0 +1,61 @@
+import datetime
+import pandas as pd
+import xarray as xr
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
+from pangeo_forge_recipes.recipes.xarray_zarr import XarrayZarrRecipe
+import zarr
+
+BASE_URL = 'http://noresg.nird.sigma2.no/thredds/fileServer/esg_dataroot/cmor/CMIP6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/Omon/vmo/gr/v20190815/vmo_Omon_NorESM2-LM_historical_r1i1p1f1_gr_'
+
+dates = pd.date_range("1850-01", "2010-01", freq="10YS")
+
+time_concat_dim = ConcatDim("time", keys=dates)
+
+
+def make_url(time):
+    """With a start date as input, return a url terminating in
+    ``{start}-{end}.nc`` where end is 10 years after the start
+    date for years other than 2010. If the start date is 2010,
+    the end date will be 5 years after the start date.
+    
+    :param date: The start date.
+    """
+    # assign 10 year interval for all years aside from 2010
+    freq = "10YS" if time.year != 2010 else "5YS"
+
+    # make a time range based on the assigned interval
+    start, end = pd.date_range(time, periods=2, freq=freq)
+
+    # subtract one day from the end of the range
+    end = end - datetime.timedelta(days=1)
+
+    # return the url with the timestamp in '%Y%m' format
+    return f"{BASE_URL}{start.strftime('%Y%m')}-{end.strftime('%Y%m')}.nc"
+
+
+pattern = FilePattern(make_url, time_concat_dim)
+
+# Decide on chunk size by downloading local copy of 1 file
+local_path = "vmo_Omon_NorESM2-LM_historical_r1i1p1f1_gr_185001-185912.nc"
+ds = xr.open_dataset(local_path)
+
+ntime = len(ds.time)       # the number of time slices
+chunksize_optimal = 125e6  # desired chunk size in bytes
+ncfile_size = ds.nbytes    # the netcdf file size
+chunksize = max(int(ntime* chunksize_optimal/ ncfile_size),1)
+
+target_chunks = ds.dims.mapping
+target_chunks['time'] = chunksize
+
+# the netcdf lists some of the coordinate variables as data variables. This is a fix which we want to apply to each chunk.
+def set_bnds_as_coords(ds):
+    new_coords_vars = [var for var in ds.data_vars if 'bnds' in var or 'bounds' in var]
+    ds = ds.set_coords(new_coords_vars)
+    return ds
+
+recipe = XarrayZarrRecipe(
+    pattern,
+    target_chunks=target_chunks,
+    process_chunk=set_bnds_as_coords,
+    xarray_concat_kwargs={'join':'exact'},
+)

--- a/recipes/noresm2-lm-hist-vmo/recipe.py
+++ b/recipes/noresm2-lm-hist-vmo/recipe.py
@@ -5,7 +5,7 @@ from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
 from pangeo_forge_recipes.recipes.xarray_zarr import XarrayZarrRecipe
 import zarr
 
-BASE_URL = 'http://noresg.nird.sigma2.no/thredds/fileServer/esg_dataroot/cmor/CMIP6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/Omon/vmo/gr/v20190815/vmo_Omon_NorESM2-LM_historical_r1i1p1f1_gr_'
+BASE_URL = 'http://esgf-data3.ceda.ac.uk/thredds/fileServer/esg_cmip6/CMIP6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/Omon/vmo/gr/v20190815/vmo_Omon_NorESM2-LM_historical_r1i1p1f1_gr_'
 
 dates = pd.date_range("1850-01", "2010-01", freq="10YS")
 


### PR DESCRIPTION
This PR has a recipe for CMIP6 NorESM2-LM historical vmo data. 

[Reference data](https://cera-www.dkrz.de/WDCC/ui/cerasearch/cmip6?input=CMIP6.CMIP.NCC.NorESM2-LM.historical) and [Further information](https://explore.es-doc.org/cmip6/further-info?target=CMIP6.NCC.NorESM2-LM.historical.none.r1i1p1f1)