### PR TITLE
Add recipe for cesm-atm-025deg

### DIFF
--- a/recipes/cesm-atm-025deg/meta.yaml
+++ b/recipes/cesm-atm-025deg/meta.yaml
@@ -1,0 +1,42 @@
+# Name for dataset. User chosen.
+ title: "cesm-atm-025deg"
+ # Description of dataset.  User chosen, roughly 1 sentence in length.
+ description: "Daily atmospheric data from coupled NCAR CESM run hybrid_v5_rel04_BC5_ne120_t12_pop62" 
+ # Version of pangeo_forge_recipes library that was used 
+ pangeo_forge_version: "0.8.3"
+ pangeo_notebook_version: "2022.05.02"
+ # The recipes section tells Pangeo Cloud where to find the recipes within your PR.
+ # Many recipe PRs will have just 1 recipe, in which case this section will look similar to the example below.
+ # If your PR contains multiple recipes, you may add additional elements to the list below.
+ recipes:
+   # User chosen name for recipe. Likely similiar to dataset name, ~25 characters in length
+   - id: cesm-atm-025deg
+     # The `object` below tells Pangeo Cloud specifically where your recipe instance(s) are located and uses the format <filename>:<object_name>
+     # <filename> is name of .py file where the Python recipe object is defined.
+     # For example, if <filename> is given as "recipe", Pangeo Cloud will expect a file named `recipe.py` to exist in your PR.
+     # <object_name> is the name of the recipe object (i.e. Python class instance) _within_ the specified file.
+     # For example, if you have defined `recipe = XarrayZarrRecipe(...)` within a file named `recipe.py`, then your  `object` below would be `"recipe:recipe"`
+     object: "recipe:recipe"
+ provenance:
+   # Data provider object.  Follow STAC spec.
+   # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object
+   providers:
+     - name: National Center for Atmospheric Research
+       description: "Daily atmospheric data from coupled NCAR CESM run hybrid_v5_rel04_BC5_ne120_t12_pop62"
+       roles:
+         - producer
+         - licensor
+         - processor
+       url: https://www.earthsystemgrid.org/dataset/ucar.cgd.asd.cs.hybrid_v5_rel04_BC5_ne120_t12_pop62.atm-regrid.proc.daily_ave.html
+   # This is a required field for provider. Follow STAC spec
+   # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
+   license: "CC-BY-4.0"
+ maintainers:
+   # Information about recipe creator. name and github are required
+   - name: "Paige Martin"
+     orcid: "0000-0003-3538-633X"
+     github: paigem
+ # The specific bakery (i.e. cloud infrastructure) that your recipe will run on.
+ # Available bakeries can be found on the Pangeo Forge website https://pangeo-forge.org/dashboard/bakeries
+ bakery:
+   id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/cesm-atm-025deg/recipe.py
+++ b/recipes/cesm-atm-025deg/recipe.py
@@ -31,8 +31,9 @@ pattern = FilePattern(
 
 # Define the recipe
 
-target_chunks = {"time": 30} # Full spatial domain: "lat": 768, "lon": 1152, --> if not specified, will include full extent
+target_chunks = {"time": 73} # Full spatial domain: "lat": 768, "lon": 1152, --> if not specified, will include full extent
 
 recipe = XarrayZarrRecipe(
             file_pattern=pattern,
-            target_chunks=target_chunks)
+            target_chunks=target_chunks,
+            subset_inputs = {"time": 5}) # set 5 chunks per year, each with time of length 73 (to total 365)

--- a/recipes/cesm-atm-025deg/recipe.py
+++ b/recipes/cesm-atm-025deg/recipe.py
@@ -1,0 +1,38 @@
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+from pangeo_forge_recipes.patterns import FilePattern, ConcatDim, MergeDim
+
+# Make FilePattern
+
+# Include all 41 years and the variables pertinent to air-sea flux calculations
+years = list(range(46,87))
+variables = [
+    "LHFLX",
+    "SHFLX",
+    "FLDS",
+    "FSNS",
+    "PSL",
+    "TAUX",
+    "TAUY",
+    "TS",
+    "U10"
+]
+
+def make_filename(variable, time):
+    return ("https://tds.ucar.edu/thredds/fileServer/datazone/campaign/cesm/collections/ASD/"
+            "hybrid_v5_rel04_BC5_ne120_t12_pop62/atm-regrid/proc/tseries/daily/FV_768x1152.bilinear."
+            f"hybrid_v5_rel04_BC5_ne120_t12_pop62.cam.h1.{variable}.00{time}0101-00{time}1231.nc")
+            
+            
+pattern = FilePattern(
+    make_filename,
+    ConcatDim(name="time", keys=years),
+    MergeDim(name="variable", keys=variables)
+)
+
+# Define the recipe
+
+target_chunks = {"time": 30} # Full spatial domain: "lat": 768, "lon": 1152, --> if not specified, will include full extent
+
+recipe = XarrayZarrRecipe(
+            file_pattern=pattern,
+            target_chunks=target_chunks)


### PR DESCRIPTION
This recipe is for the 0.25 degree atmospheric data of NCAR's Community Earth System Model (CESM) coupled to a 0.1 degree ocean (run hybrid_v5_rel04_BC5_ne120_t12_pop62). 

The atmospheric data is available as netcdf files [here](https://www.earthsystemgrid.org/dataset/ucar.cgd.asd.cs.hybrid_v5_rel04_BC5_ne120_t12_pop62.atm-regrid.proc.daily_ave.html). The ocean portion of this coupled model dataset is already [on the cloud](https://catalog.pangeo.io/browse/master/ocean/CESM_POP/).

This recipe is for all 41 years of 9 variables relevant to air-sea flux calculations.

