### PR TITLE
Adding EOOffshore CCMP v0.2.1.NRT recipe

### DIFF
--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
@@ -1,0 +1,40 @@
+# Name for dataset. User chosen.
+title: "Title for your recipe"
+# Description of dataset.  User chosen, roughly 1 sentence in length.
+description: "Long description for your recipe" 
+# Version of pangeo_forge_recipes library that was used 
+pangeo_forge_version: "0.8.2"
+# The recipes section tells Pangeo Cloud where to find the recipes within your PR.
+# Many recipe PRs will have just 1 recipe, in which case this section will look similar to the example below.
+# If your PR contains multiple recipes, you may add additional elements to the list below.
+recipes:
+  # User chosen name for recipe. Likely similiar to dataset name, ~25 characters in length
+  - id: identifier-for-your-recipe
+    # The `object` below tells Pangeo Cloud specifically where your recipe instance(s) are located and uses the format <filename>:<object_name>
+    # <filename> is name of .py file where the Python recipe object is defined.
+    # For example, if <filename> is given as "recipe", Pangeo Cloud will expect a file named `recipe.py` to exist in your PR.
+    # <object_name> is the name of the recipe object (i.e. Python class instance) _within_ the specified file.
+    # For example, if you have defined `recipe = XarrayZarrRecipe(...)` within a file named `recipe.py`, then your  `object` below would be `"recipe:recipe"`
+    object: "recipe:recipe"
+provenance:
+  # Data provider object.  Follow STAC spec.
+  # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object
+  providers:
+    - name: "NOAA NCEI"
+      description: "National Oceanographic & Atmospheric Administration National Centers for Environmental Information"
+      roles:
+        - producer
+        - licensor
+      url: https://www.ncdc.noaa.gov/oisst
+  # This is a required field for provider. Follow STAC spec
+  # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
+  license: "CC-BY-4.0"
+maintainers:
+  # Information about recipe creator. name and github are required
+  - name: "Your Full Name"
+    orcid: "Your Orchid ID"
+    github: your-github-username
+# The specific bakery (i.e. cloud infrastructure) that your recipe will run on.
+# Available bakeries can be found on the Pangeo Forge website https://pangeo-forge.org/dashboard/bakeries
+bakery:
+  id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
@@ -1,25 +1,11 @@
-# Name for dataset. User chosen.
 title: "eooffshore_ics_ccmp_v02_1_nrt_wind"
-# Description of dataset.  User chosen, roughly 1 sentence in length.
 description: "EOOffshore Project (https://eooffshore.github.io) 2015 - 2021 Cross-Calibrated Multi-Platform (CCMP) v0.2.1.NRT 6-hourly wind products for the Irish Continental Shelf region, where wind speed and direction have been calculated from the uwnd and vwnd variables." 
-# Version of pangeo_forge_recipes library that was used 
-pangeo_forge_version: "0.9.0"
-pangeo_notebook_version: "2022.05.02"
-# The recipes section tells Pangeo Cloud where to find the recipes within your PR.
-# Many recipe PRs will have just 1 recipe, in which case this section will look similar to the example below.
-# If your PR contains multiple recipes, you may add additional elements to the list below.
+pangeo_forge_version: "0.9.1"
+pangeo_notebook_version: "2022.06.02"
 recipes:
-  # User chosen name for recipe. Likely similiar to dataset name, ~25 characters in length
   - id: eooffshore_ics_ccmp_v02_1_nrt_wind
-    # The `object` below tells Pangeo Cloud specifically where your recipe instance(s) are located and uses the format <filename>:<object_name>
-    # <filename> is name of .py file where the Python recipe object is defined.
-    # For example, if <filename> is given as "recipe", Pangeo Cloud will expect a file named `recipe.py` to exist in your PR.
-    # <object_name> is the name of the recipe object (i.e. Python class instance) _within_ the specified file.
-    # For example, if you have defined `recipe = XarrayZarrRecipe(...)` within a file named `recipe.py`, then your  `object` below would be `"recipe:recipe"`
     object: "recipe:recipe"
 provenance:
-  # Data provider object.  Follow STAC spec.
-  # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object
   providers:
     - name: "Remote Sensing Systems (RSS)"
       description: "Remote Sensing Systems is a world leader in processing and analyzing microwave data collected by satellite microwave sensors, whose mission is to provide research-quality geophysical data to the global scientific community."
@@ -27,15 +13,10 @@ provenance:
         - produce
         - licensor
       url: https://www.remss.com/measurements/ccmp/
-  # This is a required field for provider. Follow STAC spec
-  # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
   license: "CC-BY-4.0" # https://rda.ucar.edu/datasets/ds745.1/
 maintainers:
-  # Information about recipe creator. name and github are required
   - name: "Derek O'Callaghan"
     orcid: "0000-0003-0585-8631"
     github: derekocallaghan
-# The specific bakery (i.e. cloud infrastructure) that your recipe will run on.
-# Available bakeries can be found on the Pangeo Forge website https://pangeo-forge.org/dashboard/bakeries
 bakery:
   id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/meta.yaml
@@ -1,15 +1,16 @@
 # Name for dataset. User chosen.
-title: "Title for your recipe"
+title: "eooffshore_ics_ccmp_v02_1_nrt_wind"
 # Description of dataset.  User chosen, roughly 1 sentence in length.
-description: "Long description for your recipe" 
+description: "EOOffshore Project (https://eooffshore.github.io) 2015 - 2021 Cross-Calibrated Multi-Platform (CCMP) v0.2.1.NRT 6-hourly wind products for the Irish Continental Shelf region, where wind speed and direction have been calculated from the uwnd and vwnd variables." 
 # Version of pangeo_forge_recipes library that was used 
-pangeo_forge_version: "0.8.2"
+pangeo_forge_version: "0.9.0"
+pangeo_notebook_version: "2022.05.02"
 # The recipes section tells Pangeo Cloud where to find the recipes within your PR.
 # Many recipe PRs will have just 1 recipe, in which case this section will look similar to the example below.
 # If your PR contains multiple recipes, you may add additional elements to the list below.
 recipes:
   # User chosen name for recipe. Likely similiar to dataset name, ~25 characters in length
-  - id: identifier-for-your-recipe
+  - id: eooffshore_ics_ccmp_v02_1_nrt_wind
     # The `object` below tells Pangeo Cloud specifically where your recipe instance(s) are located and uses the format <filename>:<object_name>
     # <filename> is name of .py file where the Python recipe object is defined.
     # For example, if <filename> is given as "recipe", Pangeo Cloud will expect a file named `recipe.py` to exist in your PR.
@@ -20,20 +21,20 @@ provenance:
   # Data provider object.  Follow STAC spec.
   # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#provider-object
   providers:
-    - name: "NOAA NCEI"
-      description: "National Oceanographic & Atmospheric Administration National Centers for Environmental Information"
+    - name: "Remote Sensing Systems (RSS)"
+      description: "Remote Sensing Systems is a world leader in processing and analyzing microwave data collected by satellite microwave sensors, whose mission is to provide research-quality geophysical data to the global scientific community."
       roles:
-        - producer
+        - produce
         - licensor
-      url: https://www.ncdc.noaa.gov/oisst
+      url: https://www.remss.com/measurements/ccmp/
   # This is a required field for provider. Follow STAC spec
   # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
-  license: "CC-BY-4.0"
+  license: "CC-BY-4.0" # https://rda.ucar.edu/datasets/ds745.1/
 maintainers:
   # Information about recipe creator. name and github are required
-  - name: "Your Full Name"
-    orcid: "Your Orchid ID"
-    github: your-github-username
+  - name: "Derek O'Callaghan"
+    orcid: "0000-0003-0585-8631"
+    github: derekocallaghan
 # The specific bakery (i.e. cloud infrastructure) that your recipe will run on.
 # Available bakeries can be found on the Pangeo Forge website https://pangeo-forge.org/dashboard/bakeries
 bakery:

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
@@ -1,7 +1,6 @@
 import dask
 import dask.array as da
 from datetime import datetime
-from metpy.calc import wind_direction, wind_speed
 import pandas as pd
 from pangeo_forge_recipes.patterns import FilePattern, ConcatDim
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
@@ -14,6 +13,7 @@ def ics_wind_speed_direction(ds: xr.Dataset, fname: str) -> xr.Dataset:
     direction for the u and v components in the specified product. Dask arrays are
     created for delayed execution.
     """
+    from metpy.calc import wind_direction, wind_speed
 
     @dask.delayed
     def delayed_metpy_fn(fn, u, v):

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import pandas as pd
 from pangeo_forge_recipes.patterns import FilePattern, ConcatDim
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
@@ -12,6 +11,7 @@ def ics_wind_speed_direction(ds, fname):
     """
     import dask
     import dask.array as da
+    from datetime import datetime
     from metpy.calc import wind_direction, wind_speed
     import xarray as xr
 

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
@@ -1,0 +1,149 @@
+import dask
+import dask.array as da
+from datetime import datetime
+from metpy.calc import wind_direction, wind_speed
+import pandas as pd
+from pangeo_forge_recipes.patterns import FilePattern, ConcatDim
+from pangeo_forge_recipes.recipes import setup_logging, XarrayZarrRecipe
+import xarray as xr
+
+
+def ics_wind_speed_direction(ds: xr.DataSet, fname: str) -> xr.DataSet:
+    """
+    Selects a subset for the Irish Continental Shelf (ICS) region, and computes wind speed and
+    direction for the u and v components in the specified product. Dask arrays are
+    created for delayed execution.
+    """
+
+    @dask.delayed
+    def delayed_metpy_fn(fn, u, v):
+        return fn(u, v).values
+
+    # ICS grid
+    geospatial_lat_min = 45.75
+    geospatial_lat_max = 58.25
+    geospatial_lon_min = 333.85
+    geospatial_lon_max = 355.35
+    icds = ds.sel(
+        latitude=slice(geospatial_lat_min, geospatial_lat_max),
+        longitude=slice(geospatial_lon_min, geospatial_lon_max),
+    )
+
+    # Remove subset of original attrs as they're no longer relevant
+    for attr in ["base_date", "date_created", "history"]:
+        del icds.attrs[attr]
+
+    # Update the grid attributes
+    icds.attrs.update(
+        {
+            "geospatial_lat_min": geospatial_lat_min,
+            "geospatial_lat_max": geospatial_lat_max,
+            "geospatial_lon_min": geospatial_lon_min,
+            "geospatial_lon_max": geospatial_lon_max,
+        }
+    )
+    u = icds.uwnd
+    v = icds.vwnd
+    # Original wind speed 'units': 'm s-1' attribute not accepted by MetPy,
+    # use the unit contained in ERA5 data
+    ccmp_wind_speed_units = u.units
+    era5_wind_speed_units = "m s**-1"
+    u.attrs["units"] = era5_wind_speed_units
+    v.attrs["units"] = era5_wind_speed_units
+
+    variables = [
+        {
+            "name": "wind_speed",
+            "metpy_fn": wind_speed,
+            "attrs": {"long_name": "Wind speed", "units": ccmp_wind_speed_units},
+        },
+        {
+            "name": "wind_direction",
+            "metpy_fn": wind_direction,
+            "attrs": {"long_name": "Wind direction", "units": "degree"},
+        },
+    ]
+
+    # CCMP provides u/v at a single height, 10m
+    for variable in variables:
+        icds[variable["name"]] = (
+            xr.DataArray(
+                da.from_delayed(
+                    delayed_metpy_fn(variable["metpy_fn"], u, v), u.shape, dtype=u.dtype
+                ),
+                coords=u.coords,
+                dims=u.dims,
+            )
+            .assign_coords(height=10)
+            .expand_dims(["height"])
+        )
+        icds[variable["name"]].attrs.update(variable["attrs"])
+
+    icds.height.attrs.update(
+        {
+            "long_name": "Height above the surface",
+            "standard_name": "height",
+            "units": "m",
+        }
+    )
+    # Restore units
+    for variable in ["uwnd", "vwnd"]:
+        icds[variable].attrs["units"] = ccmp_wind_speed_units
+
+    icds.attrs["eooffshore_zarr_creation_time"] = datetime.strftime(
+        datetime.now(), "%Y-%m-%dT%H:%M:%SZ"
+    )
+    icds.attrs[
+        "eooffshore_zarr_details"
+    ] = "EOOffshore Project: Concatenated CCMP v0.2.1.NRT 6-hourly wind products provided by Remote Sensing Systems (RSS), for Irish Continental Shelf. Wind speed and direction have been calculated from the uwnd and vwnd variables. CCMP Version-2 vector wind analyses are produced by Remote Sensing Systems. Data are available at www.remss.com."
+    return icds
+
+
+setup_logging()
+
+missing_dates = [
+    pd.Timestamp(d)
+    for d in [
+        "2017-03-11",
+        "2017-03-12",
+        "2017-04-10",
+        "2017-05-25",
+        "2017-05-26",
+        "2018-01-04",
+        "2020-07-09",
+        "2020-07-13",
+        "2020-07-15",
+        "2020-08-04",
+        "2020-08-09",
+        "2020-08-11",
+        "2020-10-22",
+        "2020-10-23",
+    ]
+]
+
+dates = pd.date_range("2015-01-16", "2021-09-30", freq="D")
+
+# Drop missing dates
+dates = dates.drop(missing_dates)
+
+
+def make_url(time):
+    year = time.strftime("%Y")
+    month = time.strftime("%m")
+    day = time.strftime("%d")
+    url = f"https://data.remss.com/ccmp/v02.1.NRT/Y{year}/M{month}/CCMP_RT_Wind_Analysis_{year}{month}{day}_V02.1_L3.0_RSS.nc"
+    return url
+
+
+pattern = FilePattern(
+    make_url,
+    ConcatDim(name="time", keys=dates),
+)
+
+target_chunks = {"time": 8000, "latitude": -1, "longitude": -1}
+
+recipe = XarrayZarrRecipe(
+    file_pattern=pattern,
+    target_chunks=target_chunks,
+    process_input=ics_wind_speed_direction,
+)

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
@@ -1,19 +1,19 @@
-import dask
-import dask.array as da
 from datetime import datetime
 import pandas as pd
 from pangeo_forge_recipes.patterns import FilePattern, ConcatDim
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
-import xarray as xr
 
 
-def ics_wind_speed_direction(ds: xr.Dataset, fname: str) -> xr.Dataset:
+def ics_wind_speed_direction(ds, fname):
     """
     Selects a subset for the Irish Continental Shelf (ICS) region, and computes wind speed and
     direction for the u and v components in the specified product. Dask arrays are
     created for delayed execution.
     """
+    import dask
+    import dask.array as da
     from metpy.calc import wind_direction, wind_speed
+    import xarray as xr
 
     @dask.delayed
     def delayed_metpy_fn(fn, u, v):

--- a/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
+++ b/recipes/eooffshore_ics_ccmp_v02_1_nrt_wind/recipe.py
@@ -8,7 +8,7 @@ from pangeo_forge_recipes.recipes import setup_logging, XarrayZarrRecipe
 import xarray as xr
 
 
-def ics_wind_speed_direction(ds: xr.DataSet, fname: str) -> xr.DataSet:
+def ics_wind_speed_direction(ds: xr.Dataset, fname: str) -> xr.Dataset:
     """
     Selects a subset for the Irish Continental Shelf (ICS) region, and computes wind speed and
     direction for the u and v components in the specified product. Dask arrays are


### PR DESCRIPTION
This recipe will create a data set containing 2015 - 2021 Cross-Calibrated Multi-Platform (CCMP) v0.2.1.NRT 6-hourly wind products for the Irish Continental Shelf region, where wind speed and direction are calculated from the `uwnd` and `vwnd` variables. The source data products are generated by [Remote Sensing Systems (RSS)](https://www.remss.com/measurements/ccmp/).

The recipe will recreate the CCMP data set used in the EOOffshore project (https://eooffshore.github.io), whose outputs were presented ([*Scalable Offshore Wind Analysis With Pangeo*](https://meetingorganizer.copernicus.org/EGU22/EGU22-2746.html)) at the [*Meeting Exascale Computing Challenges with Compression and Pangeo*](https://meetingorganizer.copernicus.org/EGU22/session/42046) [2022 EGU General Assembly](https://www.egu22.eu/) session.

Example usage of the CCMP data set in EOOffshore:
* [CCMP Wind Data for Irish Continental Shelf region](https://eooffshore.github.io/CCMP_ICS_Wind_Data.html)
* [Offshore Wind in Irish Areas Of Interest](https://eooffshore.github.io/Offshore_Wind_AOI.html)
* [Comparison of Offshore Wind Speed Extrapolation and Power Density Estimation](https://eooffshore.github.io/Comparison_Wind_Power.html)

Note:
* A pruned version of the recipe has been successfully tested in the sandbox today.
* Although `pangeo_notebook_version: "2022.05.02"` isn't in the [current sandbox `meta.yaml` template](https://github.com/pangeo-forge/sandbox/blob/main/recipe/meta.yaml), I've included it as it seems to be in recently contributed recipes. This may need to be excluded or the version changed (I couldn't determine the latter).
* Although I couldn't find the license details on the RSS site, this [NCAR/UCAR Research Data Archive page](https://rda.ucar.edu/datasets/ds745.1/) states that it's CC-BY-4.0. A separate CCMP data set has been previously used in the [NASA CCMP Winds Pangeo Gallery notebook](https://gallery.pangeo.io/repos/cgentemann/pangeo_ccmp/).
