### PR TITLE
Add ARM Vertical Radar Data from Houston

### DIFF
--- a/recipes/arm-kazr-radar/meta.yaml
+++ b/recipes/arm-kazr-radar/meta.yaml
@@ -1,0 +1,25 @@
+title: "ARM KAZR Radar"
+description: >
+  Vertically pointing radar data from the Atmospheric Radiation Measurement (ARM) user facility,
+  from the TRACER field campaign in Houston, Texas.
+pangeo_forge_version: "0.8.3"
+pangeo_notebook_version: "2022.06.02"
+recipes:
+  - id: arm-kazr-radar
+    object: "recipe:recipe"
+provenance:
+  providers:
+    - name: "ARM DOE"
+      description: "Atmospheric Radiation Measurement Department of Energy user facility"
+      roles:
+        - host
+        - licensor
+        - producer
+      url: https://adc.arm.gov/discovery/#/results/s::houkazr
+  license: "No constraints on data access or use."
+maintainers:
+  - name: "Max Grover"
+    orcid: "0000-0002-0370-8974"
+    github: mgrover1
+bakery:
+  id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/arm-kazr-radar/recipe.py
+++ b/recipes/arm-kazr-radar/recipe.py
@@ -1,0 +1,64 @@
+from pangeo_forge_recipes.patterns import FilePattern, pattern_from_file_sequence
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+from urllib.request import urlopen
+import json
+from datetime import datetime
+import os
+
+
+def format_time(time):
+    """
+    Parameters
+    ----------
+    time: datetime
+      Time object you desire to convert
+
+    Returns
+    ----------
+    time_string: str
+      Datetime string ready to input into ARM data query
+    Convert
+    """
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def create_url_path(file, username, password):
+    url = f"https://adc.arm.gov/armlive/data/saveData?file={file}&user={username}:{password}"
+    return url
+
+def get_list_of_files(datastream, start_time, end_time, username, password):
+    start = format_time(start_time)
+    end = format_time(end_time)
+
+    url = f"https://adc.arm.gov/armlive/data/query?ds={datastream}&start={start}&end={end}&wt=json&user={username}:{password}"
+
+    # Read the remote json
+    response = urlopen(url)
+    data_json = json.loads(response.read())
+    files = [create_url_path(x, username, password) for x in data_json["files"]]
+
+    return files
+
+start_time = datetime(2022, 6, 1, 0)
+end_time = datetime(2022, 6, 2, 0)
+
+# Make sure to access your username and password from here
+# https://adc.arm.gov/armlive/livedata/home
+username = os.environ("arm_username")
+password = os.environ("arm_password")
+
+files = get_list_of_files("houkazrcfrgeM1.a1",
+                          start_time=start_time,
+                          end_time=end_time,
+                          username=username,
+                          password=password)
+
+pattern = pattern_from_file_sequence(
+     files,
+     "time",
+     file_type='netcdf4'
+ )
+
+recipe = XarrayZarrRecipe(
+     pattern,
+     target_chunks={"time": 600},
+ )


### PR DESCRIPTION
Add data from the TRACER field campaign in Houston, Texas.

The data is hosted on [ARM Data Portal](https://adc.arm.gov/discovery/#/) and the data files are queried + downloaded using the [ARM Live API](https://adc.arm.gov/armlive/livedata/home).

We will need to create credentials for Pangeo Forge, and add those credentials to the cloud environment/repo.