### PR TITLE
Add HadISST recipe

### DIFF
--- a/recipes/HadISST/meta.yaml
+++ b/recipes/HadISST/meta.yaml
@@ -1,0 +1,22 @@
+title: "Hadley Centre Sea Ice and Sea Surface Temperature (HadISST)"
+description: "Analysis-ready Zarr datasets derived from HadISST NetCDF"
+pangeo_forge_version: "0.8.3"
+pangeo_notebook_version: "2021.12.02"
+recipes:
+  - id: hadisst
+    object: "recipe:recipe"
+provenance:
+  providers:
+    - name: "Met Office Hadley Centre"
+      description: "Met Office Hadley Centre"
+      roles:
+        - producer
+        - licensor
+      url: https://www.metoffice.gov.uk/hadobs/hadisst/index.html
+  license: "TBD" # I need some help encoding this properly (see discussion)
+maintainers:
+  - name: "Julius Busecke"
+    orcid: "0000-0001-8571-865X"
+    github: jbusecke
+bakery:
+  id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/HadISST/recipe.py
+++ b/recipes/HadISST/recipe.py
@@ -9,4 +9,4 @@ def make_full_path(mock_concat):
     return url.format(mock_concat=mock_concat)
 filepattern = FilePattern(make_full_path, time_concat_dim, file_type="netcdf3")
 
-recipe = XarrayZarrRecipe(filepattern)
+recipe = XarrayZarrRecipe(filepattern, copy_input_to_local_file=True)

--- a/recipes/HadISST/recipe.py
+++ b/recipes/HadISST/recipe.py
@@ -1,0 +1,12 @@
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
+from pangeo_forge_recipes.recipes.xarray_zarr import XarrayZarrRecipe
+
+url = "{mock_concat}https://www.metoffice.gov.uk/hadobs/hadisst/data/HadISST_sst.nc.gz"
+
+time_concat_dim = ConcatDim("mock_concat", [""], nitems_per_file=1)
+
+def make_full_path(mock_concat):
+    return url.format(mock_concat=mock_concat)
+filepattern = FilePattern(make_full_path, time_concat_dim, file_type="netcdf3")
+
+recipe = XarrayZarrRecipe(filepattern)


### PR DESCRIPTION
I am submitting this recipe as parts of an effort to [fully reproduce IPCC plots in the cloud](https://github.com/jbusecke/presentation_scipy_2022_cmip). 
This will add [HadISST](https://www.metoffice.gov.uk/hadobs/hadisst/index.html) to pangeo forge.

## Open Questions:
- I am not familiar with the type of license (["Crown copyright protection and is provided under a Non-Commercial Government Licence"](https://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/)), can anybody assist me with encoding this properly into the `meta.yaml`?