### PR TITLE
Recipes for daily eNATL60 at depth data

### DIFF
--- a/recipes/eNATL60/meta.yaml
+++ b/recipes/eNATL60/meta.yaml
@@ -1,0 +1,27 @@
+title: "eNATL60 with tides daily data"
+description: "extractions of temperature, salinity and vertical currents at some chosen depths from eNATL60 NEMO simulation with tides" 
+pangeo_forge_version: "0.8.3"
+recipes:
+  - id: eNATL60_wtides_1d_mld
+    object: "recipe:eNATL60_wtides_1d_mld"
+  - id: eNATL60_wtides_1d_tsw60m
+    object: "recipe:eNATL60_wtides_1d_tsw60m"
+  - id: eNATL60_wtides_1d_tsw600m
+    object: "recipe:eNATL60_wtides_1d_tsw600m"
+provenance:
+  providers:
+    - name: "MEOM IGE"
+      description: "Multiscale Ocean Modelling Group, Institut des Geosciences de l'Environnement, Grenoble, France"
+      roles:
+        - producer
+        - licensor
+      url: http://meom-group.github.io/
+  # This is a required field for provider. Follow STAC spec
+  # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
+  license: "CC-BY-4.0"
+maintainers:
+  - name: "Aurélie Albert"
+    orcid: "0000-0001-7783-5629"
+    github: auraoupa
+bakery:
+  id: "pangeo-ldeo-nsf-earthcube"

--- a/recipes/eNATL60/meta.yaml
+++ b/recipes/eNATL60/meta.yaml
@@ -1,16 +1,16 @@
-title: "eNATL60 with tides daily data"
-description: "extractions of temperature, salinity and vertical velocity at some chosen depths from eNATL60 NEMO simulation with tides" 
-pangeo_forge_version: "0.8.3"
+title: 'eNATL60 with tides daily data'
+description: 'extractions of temperature, salinity and vertical velocity at some chosen depths from eNATL60 NEMO simulation with tides'
+pangeo_forge_version: '0.8.3'
 recipes:
   - id: eNATL60_wtides_1d_mld
-    object: "recipe:eNATL60_wtides_1d_mld"
+    object: 'recipe:eNATL60_wtides_1d_mld'
   - id: eNATL60_wtides_1d_tsw60m
-    object: "recipe:eNATL60_wtides_1d_tsw60m"
+    object: 'recipe:eNATL60_wtides_1d_tsw60m'
   - id: eNATL60_wtides_1d_tsw600m
-    object: "recipe:eNATL60_wtides_1d_tsw600m"
+    object: 'recipe:eNATL60_wtides_1d_tsw600m'
 provenance:
   providers:
-    - name: "MEOM IGE"
+    - name: 'MEOM IGE'
       description: "Multiscale Ocean Modelling Group, Institut des Geosciences de l'Environnement, Grenoble, France"
       roles:
         - producer
@@ -18,10 +18,10 @@ provenance:
       url: http://meom-group.github.io/
   # This is a required field for provider. Follow STAC spec
   # https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#license
-  license: "CC-BY-4.0"
+  license: 'CC-BY-4.0'
 maintainers:
-  - name: "Aurélie Albert"
-    orcid: "0000-0001-7783-5629"
+  - name: 'Aurélie Albert'
+    orcid: '0000-0001-7783-5629'
     github: auraoupa
 bakery:
-  id: "pangeo-ldeo-nsf-earthcube"
+  id: 'pangeo-ldeo-nsf-earthcube'

--- a/recipes/eNATL60/meta.yaml
+++ b/recipes/eNATL60/meta.yaml
@@ -1,5 +1,5 @@
 title: "eNATL60 with tides daily data"
-description: "extractions of temperature, salinity and vertical currents at some chosen depths from eNATL60 NEMO simulation with tides" 
+description: "extractions of temperature, salinity and vertical velocity at some chosen depths from eNATL60 NEMO simulation with tides" 
 pangeo_forge_version: "0.8.3"
 recipes:
   - id: eNATL60_wtides_1d_mld

--- a/recipes/eNATL60/recipe.py
+++ b/recipes/eNATL60/recipe.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import xarray as xr
 
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe

--- a/recipes/eNATL60/recipe.py
+++ b/recipes/eNATL60/recipe.py
@@ -19,7 +19,7 @@ def make_recipe(var,dep):
         return recipe
 
 eNATL60_wtides_1d_mld = make_recipe('somxl010','')
-eNATL60_wtides_1d_tsw60m = make_recipe('TSW','60m')
-eNATL60_wtides_1d_tsw600m = make_recipe('TSW','600m')
+eNATL60_wtides_1d_tsw60m = make_recipe('TSW','_60m')
+eNATL60_wtides_1d_tsw600m = make_recipe('TSW','_600m')
 
 

--- a/recipes/eNATL60/recipe.py
+++ b/recipes/eNATL60/recipe.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import xarray as xr
+
+from pangeo_forge_recipes.patterns import pattern_from_file_sequence
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+
+dates = pd.date_range('2009-07-01', '2010-06-30', freq='D')
+
+url_base = (
+    "https://ige-meom-opendap.univ-grenoble-alpes.fr"
+    "/thredds/fileServer/meomopendap/extract/eNATL60/eNATL60-BLBT02/1d"
+)
+
+def make_recipe(var,dep):
+        input_url_pattern = url_base + "/eNATL60-BLBT02_y{time:%Y}m{time:%m}d{time:%d}.1d_"+var+dep+".nc"
+        input_urls= [ input_url_pattern.format(time=time) for time in dates ]
+        pattern = pattern_from_file_sequence(input_urls, "time_counter")
+        recipe = XarrayZarrRecipe(pattern, target_chunks={"time_counter": 1})
+        return recipe
+
+eNATL60_wtides_1d_mld = make_recipe('somxl010','')
+eNATL60_wtides_1d_tsw60m = make_recipe('TSW','60m')
+eNATL60_wtides_1d_tsw600m = make_recipe('TSW','600m')
+
+

--- a/recipes/eNATL60/recipe.py
+++ b/recipes/eNATL60/recipe.py
@@ -6,19 +6,21 @@ from pangeo_forge_recipes.recipes import XarrayZarrRecipe
 dates = pd.date_range('2009-07-01', '2010-06-30', freq='D')
 
 url_base = (
-    "https://ige-meom-opendap.univ-grenoble-alpes.fr"
-    "/thredds/fileServer/meomopendap/extract/eNATL60/eNATL60-BLBT02/1d"
+    'https://ige-meom-opendap.univ-grenoble-alpes.fr'
+    '/thredds/fileServer/meomopendap/extract/eNATL60/eNATL60-BLBT02/1d'
 )
 
-def make_recipe(var,dep):
-        input_url_pattern = url_base + "/eNATL60-BLBT02_y{time:%Y}m{time:%m}d{time:%d}.1d_"+var+dep+".nc"
-        input_urls= [ input_url_pattern.format(time=time) for time in dates ]
-        pattern = pattern_from_file_sequence(input_urls, "time_counter")
-        recipe = XarrayZarrRecipe(pattern, target_chunks={"time_counter": 1})
-        return recipe
 
-eNATL60_wtides_1d_mld = make_recipe('somxl010','')
-eNATL60_wtides_1d_tsw60m = make_recipe('TSW','_60m')
-eNATL60_wtides_1d_tsw600m = make_recipe('TSW','_600m')
+def make_recipe(var, dep):
+    input_url_pattern = (
+        url_base + '/eNATL60-BLBT02_y{time:%Y}m{time:%m}d{time:%d}.1d_' + var + dep + '.nc'
+    )
+    input_urls = [input_url_pattern.format(time=time) for time in dates]
+    pattern = pattern_from_file_sequence(input_urls, 'time_counter')
+    recipe = XarrayZarrRecipe(pattern, target_chunks={'time_counter': 1})
+    return recipe
 
 
+eNATL60_wtides_1d_mld = make_recipe('somxl010', '')
+eNATL60_wtides_1d_tsw60m = make_recipe('TSW', '_60m')
+eNATL60_wtides_1d_tsw600m = make_recipe('TSW', '_600m')


### PR DESCRIPTION
These recipes will create datasets containing some NEMO based runs outputs, more specifically temperature, salinity and vertical velocities at some depths (60m and 600m) + mixed layer depth. This datasets will be useful to M2LINES participants for spatial filtering testing, w’b’ computations, model training, etc …

The recipes have been successfully prune-tested on m2lines cloud with version 0.8.3 of pangeo_forge_recipes. The data are retrievable through opendap.

Two questions :

  - is it possible to define a compression rate for the resulting zarrs and if yes how ?
  - I will probably want to upload some more levels in the near future, will I have to set up a new contribution or could I amend this one later ?