### PR TITLE
RCM/S1 Sea Ice Motion

### DIFF
--- a/recipes/rcms1sim/meta.yaml
+++ b/recipes/rcms1sim/meta.yaml
@@ -1,0 +1,29 @@
+title: "RCMS1SIM"
+description: "RADARSAT Constellation Mission / Sentinel-1 Sea Ice Motion (RCMS1SIM) coarse-grid (RCMS1SIM_LR: 25km EASE1) and fine-grid (RCMS1SIM_HR: 6.25km EASE2) data available from the Climate Research Division (CRD)"
+pangeo_forge_version: "0.9.4"
+recipes:
+  - id: rcms1sim_lr
+    object: "recipe_lr:recipe"
+  - id: rcms1sim_hr
+    object: "recipe_hr:recipe"
+provenance:
+  providers:
+    - name: "ECCC"
+      description: "Environment and Climate Change Canada"
+      roles:
+        - producer
+        - processor
+        - host
+      url: https://catalogue.ec.gc.ca/geonetwork/srv/eng/catalog.search#/metadata/09ab22c4-e211-4d23-afe6-9e7aa6831c62
+    - name: "Government of Canada"
+      description: "Government of Canada"
+      roles:
+        - licensor
+      url: https://open.canada.ca/data/en/dataset/22aa3b41-425f-4f67-9747-f097c00e3eb1
+  license: OGL-Canada-2.0
+maintainers:
+  - name: "Mike Brady"
+    orcid: 0000-0001-8263-0951
+    github: m9brady
+bakery:
+  id: "pangeo-ledo-nsf-earthcube"

--- a/recipes/rcms1sim/recipe_hr.py
+++ b/recipes/rcms1sim/recipe_hr.py
@@ -1,0 +1,40 @@
+from datetime import date, timedelta
+
+import pandas as pd
+
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+
+# 6.25km products have 3-day window
+rcms1sim_hr_tdelta = timedelta(days=2)
+
+input_url_pattern = (
+    'https://crd-data-donnees-rdc.ec.gc.ca/CPS/products/RCMS1SIM/RCMS1SIM_6250m_EASE2/'
+    '{yyyy}/RCMS1SIM_{syyyymmdd}_{eyyyymmdd}_EASE2_v1.0.nc'
+)
+
+# products are generated and published daily with 2-day lag
+latest = date.today() - timedelta(days=2)
+dates = pd.date_range('2020-03-08', latest, freq='1D')
+
+def make_url(time):
+    return input_url_pattern.format(
+        yyyy=(time + rcms1sim_hr_tdelta).year,
+        syyyymmdd=time.strftime('%Y%m%d'),
+        eyyyymmdd=(time + rcms1sim_hr_tdelta).strftime('%Y%m%d')        
+    )
+
+pattern = FilePattern(
+    make_url,
+    ConcatDim(
+        name='time',
+        keys=dates,
+        nitems_per_file=1
+    )
+)
+# each file is pretty big (~88MB)
+# v2.0 will likely be a subset of the default 2880x2880 EASE2 extent)
+recipe = XarrayZarrRecipe(
+    pattern, 
+    inputs_per_chunk=1
+)

--- a/recipes/rcms1sim/recipe_lr.py
+++ b/recipes/rcms1sim/recipe_lr.py
@@ -1,0 +1,39 @@
+from datetime import date, timedelta
+
+import pandas as pd
+
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
+from pangeo_forge_recipes.recipes import XarrayZarrRecipe
+
+# 25km products have 7-day window
+rcms1sim_lr_tdelta = timedelta(days=6)
+
+input_url_pattern = (
+    'https://crd-data-donnees-rdc.ec.gc.ca/CPS/products/RCMS1SIM/RCMS1SIM_25000m_EASE1/'
+    '{yyyy}/RCMS1SIM_{syyyymmdd}_{eyyyymmdd}_EASE1_v1.0.nc'
+)
+
+# products are generated and published daily with 2-day lag
+latest = date.today() - timedelta(days=2)
+dates = pd.date_range('2020-03-04', latest, freq='1D')
+
+def make_url(time):
+    return input_url_pattern.format(
+        yyyy=(time + rcms1sim_lr_tdelta).year,
+        syyyymmdd=time.strftime('%Y%m%d'),
+        eyyyymmdd=(time + rcms1sim_lr_tdelta).strftime('%Y%m%d')        
+    )
+
+pattern = FilePattern(
+    make_url,
+    ConcatDim(
+        name='time',
+        keys=dates,
+        nitems_per_file=1
+    )
+)
+# 20 files per chunk seems good
+recipe = XarrayZarrRecipe(
+    pattern, 
+    inputs_per_chunk=20
+)


### PR DESCRIPTION
I have a multi-item recipe that is hopefully suitable for this project. 

RADARSAT Constellation Mission / Sentinel-1 Sea Ice Motion (RCMS1SIM) netcdf products at 2 grid specs:

https://open.canada.ca/data/en/dataset/22aa3b41-425f-4f67-9747-f097c00e3eb1

###  `rcms1sim_lr` (RCMS1SIM Low Resolution):
25km Equal-Area Scalable Earth North Hemisphere version 1 (EASE1, EPSG:3408)

### `rcms1sim_hr` (RCMS1SIM High Resolution):
6.25km Equal Area Scalable Earth North Hemisphere version 2 (EASE2, EPSG:6931)

I have run the recipes locally using pruned versions and they appear to work as expected. I do have one question that I'm hoping to get advice on:

For the `rcms1sim_lr` there are 2D lat/lon variables that for some reason are being concatenated along the `time` axis and I can't figure out why. Is it possible to squeeze these variables before they are converted to zarr using a preprocessing function, or is that generally not encouraged? The `rcms1sim_hr` appears to properly squeeze these data arrays.